### PR TITLE
Make ValueObject abstract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
     {
       "name": "Raúl Araya Tauler",
       "email": "nubeiro@gmail.com"
+    },
+    {
+      "name": "Daniel Santamaría",
+      "email": "santaka87@gmail.com"
     }
   ],
   "require": {

--- a/src/Base/Boolean.php
+++ b/src/Base/Boolean.php
@@ -11,16 +11,31 @@ use ValueObjects\ValueObject;
  */
 class Boolean extends ValueObject
 {
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param bool $boolean
+     */
     public function __construct(bool $boolean)
     {
-        parent::__construct($boolean);
+        $this->value = $boolean;
     }
 
+    /**
+     * @return bool
+     */
     public function value(): bool
     {
         return (bool) $this->value;
     }
 
+    /**
+     * @param int $int
+     * @return self
+     */
     public static function fromInt(int $int): self
     {
         $result = $int !== 0 ? true : false;
@@ -28,11 +43,19 @@ class Boolean extends ValueObject
         return new static($result);
     }
 
+    /**
+     * @param string $string
+     * @return self
+     */
     public static function fromString(string $string): self
     {
         return new static(strcasecmp('true', $string) === 0);
     }
 
+    /**
+     * @param self $boolean
+     * @return self
+     */
     public function and(self $boolean): self
     {
         $andResult = $this->value && $boolean->value;
@@ -40,6 +63,10 @@ class Boolean extends ValueObject
         return new static($andResult);
     }
 
+    /**
+     * @param self $boolean
+     * @return self
+     */
     public function or(self $boolean): self
     {
         $orResult = $this->value || $boolean->value;
@@ -47,6 +74,9 @@ class Boolean extends ValueObject
         return new static($orResult);
     }
 
+    /**
+     * @return self
+     */
     public function not(): self
     {
         $notResult = !$this->value;
@@ -54,6 +84,10 @@ class Boolean extends ValueObject
         return new static($notResult);
     }
 
+    /**
+     * @param self $boolean
+     * @return self
+     */
     public function xor(self $boolean): self
     {
         $xorResult = ($this->value xor $boolean->value);
@@ -61,6 +95,9 @@ class Boolean extends ValueObject
         return new static($xorResult);
     }
 
+    /**
+     * @return string
+     */
     public function __toString(): string
     {
         return $this->value ? 'true' : 'false';

--- a/src/Base/Identifier.php
+++ b/src/Base/Identifier.php
@@ -19,23 +19,42 @@ use ValueObjects\ValueObject;
  */
 class Identifier extends ValueObject
 {
+    /**
+     * @var UuidInterface
+     */
+    private $value;
+
+    /**
+     * Identifier constructor.
+     * @param UuidInterface $identifier
+     */
     public function __construct(UuidInterface $identifier)
     {
-        parent::__construct($identifier);
+        $this->value = $identifier;
     }
 
-    public function equals(ValueObject $identifier): bool
-    {
-        return (string) $this == (string) $identifier;
-    }
-
+    /**
+     * @return Identifier
+     */
     public static function generate(): self
     {
         return new static(Uuid::uuid1());
     }
 
+    /**
+     * @param string $identifier
+     * @return Identifier
+     */
     public static function fromString(string $identifier): self
     {
         return new static(Uuid::fromString($identifier));
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return (string) $this->value;
     }
 }

--- a/src/Base/Number.php
+++ b/src/Base/Number.php
@@ -11,20 +11,37 @@ use ValueObjects\ValueObject;
  */
 class Number extends ValueObject
 {
-    public function __construct($value)
+    /**
+     * @var mixed
+     */
+    private $number;
+
+    /**
+     * Number constructor.
+     * @param $number
+     */
+    public function __construct($number)
     {
-        $this->validate($value);
-        parent::__construct($value);
+        $this->validate($number);
+        $this->number = $number;
     }
 
     /**
      * Validates that the number is numeric.
-     * @param $value
+     * @param mixed $value
      */
     protected function validate($value)
     {
         if (!is_numeric($value) || is_bool($value)) {
             throw new \InvalidArgumentException("Can't create a Number from a non numeric value.");
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return (string) $this->number;
     }
 }

--- a/src/Base/Strings.php
+++ b/src/Base/Strings.php
@@ -12,9 +12,17 @@ use ValueObjects\ValueObject;
  */
 class Strings extends ValueObject
 {
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
     public function __construct(string $value)
     {
-        parent::__construct($value);
+        $this->value = $value;
     }
 
     /**
@@ -28,7 +36,7 @@ class Strings extends ValueObject
     }
 
     /**
-     * Cretes a string from a double.
+     * Creates a string from a double.
      * @param float $double
      * @return Strings
      */
@@ -71,5 +79,13 @@ class Strings extends ValueObject
     public function length(): int
     {
         return mb_strlen($this->value);
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->value;
     }
 }

--- a/src/Internet/Email.php
+++ b/src/Internet/Email.php
@@ -11,16 +11,36 @@ use ValueObjects\ValueObject;
  */
 class Email extends ValueObject
 {
+    /**
+     * @var string
+     */
+    private $email;
+
+    /**
+     * @param string $email
+     */
     public function __construct(string $email)
     {
         $this->validate($email);
-        parent::__construct($email);
+        $this->email = $email;
     }
 
-    private function validate($email)
+    /**
+     * @param string $email
+     * @throws \InvalidArgumentException
+     */
+    private function validate(string $email)
     {
         if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
             throw new \InvalidArgumentException("$email is not a valid e-mail address.");
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->email;
     }
 }

--- a/src/Internet/IpAddress.php
+++ b/src/Internet/IpAddress.php
@@ -7,19 +7,36 @@ use ValueObjects\ValueObject;
 class IpAddress extends ValueObject
 {
     /**
+     * @var string
+     */
+    private $value;
+
+    /**
      * IpAddress constructor.
      * @param string $ipAddress The ip address.
      */
     public function __construct(string $ipAddress)
     {
         $this->validate($ipAddress);
-        parent::__construct($ipAddress);
+        $this->value = $ipAddress;
     }
 
-    private function validate($ipAddress)
+    /**
+     * @param string $ipAddress
+     * @throws \InvalidArgumentException
+     */
+    private function validate(string $ipAddress)
     {
         if (filter_var($ipAddress, FILTER_VALIDATE_IP) === false) {
             throw new \InvalidArgumentException("$ipAddress is not a valid ip address.");
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->value;
     }
 }

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -7,22 +7,17 @@ namespace ValueObjects;
  * Generic Base class where all the other extend.
  * @package ValueObjects
  */
-class ValueObject
+abstract class ValueObject implements ValueObjectInterface
 {
-    protected $value;
-
-    public function __construct($value)
+    /**
+     * @param ValueObjectInterface $other
+     * @return bool
+     */
+    public function equals(ValueObjectInterface $other): bool
     {
-        $this->value = $value;
-    }
-
-    public function __toString(): string
-    {
-        return (string) $this->value;
-    }
-
-    public function equals(self $value2): bool
-    {
-        return $this->value === $value2->value;
+        if (get_class($this) !== get_class($other)) {
+            throw new \InvalidArgumentException(sprintf('A Value Object of type %s can not be compared to another of type %s', get_class($this), get_class($other)));
+        }
+        return $this == $other;
     }
 }

--- a/src/ValueObjectInterface.php
+++ b/src/ValueObjectInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ValueObjects;
+
+interface ValueObjectInterface
+{
+    /**
+     * @return string
+     */
+    public function __toString(): string;
+
+    /**
+     * @param self $other
+     * @return bool
+     */
+    public function equals(self $other): bool;
+}

--- a/tests/Base/NumberTest.php
+++ b/tests/Base/NumberTest.php
@@ -2,8 +2,6 @@
 
 namespace ValueObjects\Base;
 
-use ValueObjects\ValueObject;
-
 use PHPUnit\Framework\TestCase;
 
 class NumberTest extends TestCase
@@ -31,7 +29,7 @@ class NumberTest extends TestCase
         ];
 
         $set['an object'] = [
-            'value' => new ValueObject(1)
+            'value' => new \stdClass()
         ];
 
         $set['a boolean'] = [

--- a/tests/ValueObjectTest.php
+++ b/tests/ValueObjectTest.php
@@ -8,22 +8,81 @@ class ValueObjectTest extends TestCase
 {
     public function testWeCanDefineAValueObject()
     {
-        $value = new ValueObject(123);
+        $value = $this->valueObjectWithValue(123);
         $this->assertInstanceOf(ValueObject::class, $value);
     }
 
     public function testAValueObjectCanBeCastedToString()
     {
-        $value = new ValueObject(123);
+        $value = $this->valueObjectWithValue(123);
         $this->assertEquals("123", $value);
     }
 
     public function testEqualityIsBasedOnValueAndNotOnInstace()
     {
-        $value1 = new ValueObject(123);
-        $value2 = new ValueObject(123);
+        $value1 = $this->valueObjectWithValue(123);
+        $value2 = $this->valueObjectWithValue(123);
 
         $this->assertNotSame($value1, $value2);
         $this->assertTrue($value1->equals($value2));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testTwoValueObjectsOfDifferentTypesCanNotBeCompared()
+    {
+        $value1 = new ValueObjectA();
+        $value2 = new ValueObjectB();
+
+        $value1->equals($value2);
+    }
+
+    private function valueObjectWithValue($value)
+    {
+        return new class($value) extends ValueObject {
+            /**
+             * @var string
+             */
+            private $value;
+
+            /**
+             * @param string $value
+             */
+            public function __construct(string $value)
+            {
+                $this->value = $value;
+            }
+
+            /**
+             * @return string
+             */
+            public function __toString(): string
+            {
+                return $this->value;
+            }
+        };
+    }
+}
+
+class ValueObjectA extends ValueObject
+{
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return '';
+    }
+}
+
+class ValueObjectB extends ValueObject
+{
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return '';
     }
 }


### PR DESCRIPTION
- Added ValueObjectInterface
- Make ValueObject abstract. This allow us to implement Value Objects with more properties. For example Money VO (value + currency)
- Use built in PHP object comparision for "equals" method. http://php.net/manual/en/language.oop5.object-comparison.php
- Prevent comparing two Value Objects of different types
- Added PHPDoc